### PR TITLE
Fix web info

### DIFF
--- a/lib/sys_info.dart
+++ b/lib/sys_info.dart
@@ -24,8 +24,6 @@ class SystemInfo {
   static const String _kIPhoneOsName = "iOS";
   static const String _kMacOsName = "macOS";
   static const String _kWindowsOsName = "Windows";
-  static const String _kWebOsName = "";
-  static const String _kWebOsVersion = "";
 
   static const String _kUnknownOsVersion = "";
   static const String _kIpadModelString = "ipad";
@@ -36,9 +34,13 @@ class SystemInfo {
 
     final packageInfo = await PackageInfo.fromPlatform();
 
+    final osVersion = osInfo.version.length > 100
+        ? osInfo.version.substring(0, 100)
+        : osInfo.version;
+
     return SystemInfo._(
       osName: osInfo.name,
-      osVersion: osInfo.version,
+      osVersion: osVersion,
       locale: Platform.localeName,
       buildNumber: packageInfo.buildNumber,
       appVersion: packageInfo.version,
@@ -47,11 +49,16 @@ class SystemInfo {
 
   /// Returns info (name and version) of the operating system.
   static Future<({String name, String version})> _getOsInfo() async {
-    if (kIsWeb) {
-      return (name: _kWebOsName, version: _kWebOsVersion);
-    }
-
     final deviceInfo = DeviceInfoPlugin();
+
+    if (kIsWeb) {
+      final info = await deviceInfo.webBrowserInfo;
+
+      return (
+        name: info.browserName.name,
+        version: info.appVersion ?? "",
+      );
+    }
 
     if (Platform.isAndroid) {
       final info = await deviceInfo.androidInfo;


### PR DESCRIPTION
Related to item 3 in #13. Quoting:

## 3. Fix web info

In web is flagging OS as unknown.
In package DeviceInfoPlugin has the implementation for web platform, check out in [pub.dev example](https://pub.dev/packages/device_info_plus/example)

Already change to use the `webBrowserInfo`

![CleanShot 2024-09-03 at 13 09 36](https://github.com/user-attachments/assets/d5cbe4c0-23e7-439b-aa89-52f05f28aba6)

The issue here is the `version` part as the web provides not a clear single option to use.

In documentation has these info:

```
 Map<String, dynamic> _readWebBrowserInfo(WebBrowserInfo data) {
    return <String, dynamic>{
      'browserName': data.browserName.name,
      'appCodeName': data.appCodeName,
      'appName': data.appName,
      'appVersion': data.appVersion,
      'deviceMemory': data.deviceMemory,
      'language': data.language,
      'languages': data.languages,
      'platform': data.platform,
      'product': data.product,
      'productSub': data.productSub,
      'userAgent': data.userAgent,
      'vendor': data.vendor,
      'vendorSub': data.vendorSub,
      'hardwareConcurrency': data.hardwareConcurrency,
      'maxTouchPoints': data.maxTouchPoints,
    };
  }
```

Here is my debug value:
![CleanShot 2024-09-03 at 12 55 04@2x](https://github.com/user-attachments/assets/2c170e64-14be-4c2e-9cfb-10260b14f2fd)

We could use the `appVersion` but still not so clear and simple.
And yet we should limit it to 100 max chars as server defined.
_39:_ `osInfo.version.substring(0, 100),`