### PR TITLE
Fix appKey invalid message

### DIFF
--- a/lib/aptabase_flutter.dart
+++ b/lib/aptabase_flutter.dart
@@ -71,7 +71,7 @@ class Aptabase {
 
     if (parts.length != 3 || _hosts[parts[1]] == null) {
       _logError(
-        "The Aptabase App Key '$_appKey' is invalid. "
+        "The Aptabase App Key '$appKey' is invalid. "
         "Tracking will be disabled.",
       );
 


### PR DESCRIPTION
The `_appKey` is not attributed yet, so in the error message will always shows as null. 
Should show the `appKey` (from user value) instead `_appKey` (local var)

Related to #13